### PR TITLE
New feature: Generate data for individual isolines

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ def run_simple_heat_pump_model():
 
     result_dict = {
         'compressor': {
-            'isoline_type': 's',
+            'isoline_property': 's',
             'isoline_value': ev_cp.s.val,
             'isoline_value_end': cp_cc.s.val,
             'starting_point_property': 'p',
@@ -53,7 +53,7 @@ def run_simple_heat_pump_model():
             'ending_point_value': cp_cc.p.val
         },
         'condenser': {
-            'isoline_type': 'p',
+            'isoline_property': 'p',
             'isoline_value': cc_cd.p.val,
             'isoline_value_end': cd_va.p.val,
             'starting_point_property': 's',
@@ -62,7 +62,7 @@ def run_simple_heat_pump_model():
             'ending_point_value': cd_va.s.val
         },
         'valve': {
-            'isoline_type': 'h',
+            'isoline_property': 'h',
             'isoline_value': cd_va.h.val,
             'isoline_value_end': va_ev.h.val,
             'starting_point_property': 'p',
@@ -71,7 +71,7 @@ def run_simple_heat_pump_model():
             'ending_point_value': va_ev.p.val
         },
         'evaporator': {
-            'isoline_type': 'p',
+            'isoline_property': 'p',
             'isoline_value': va_ev.p.val,
             'isoline_value_end': ev_cp.p.val,
             'starting_point_property': 's',
@@ -131,15 +131,19 @@ mydata = {
 diagram.draw_isolines('logph', isoline_data=mydata)
 diagram.save('reference/_images/logph_NH3_zoomed_temperature_labels.svg')
 
+diagram.set_limits(x_min=0, x_max=2100, y_min=1e0, y_max=2e2)
+mydata = {
+    'Q': {'values': np.linspace(0, 1, 11)},
+    'T': {
+        'values': np.arange(-25, 226, 25),
+        'style': {'color': '#000000'}
+    }
+}
+diagram.draw_isolines('logph', isoline_data=mydata)
+
 tespy_results = run_simple_heat_pump_model()
 for key, data in tespy_results.items():
     tespy_results[key]['datapoints'] = diagram.calc_individual_isoline(**data)
-
-diagram.set_limits(x_min=0, x_max=2100, y_min=1e-1, y_max=2e2)
-mydata = {
-    'Q': {'values': np.linspace(0, 1, 11)},
-    'T': {'values': np.arange(-50, 201, 25)}}
-diagram.draw_isolines('logph', isoline_data=mydata)
 
 for key in tespy_results.keys():
     datapoints = tespy_results[key]['datapoints']
@@ -147,7 +151,7 @@ for key in tespy_results.keys():
     diagram.ax.scatter(datapoints['h'][0], datapoints['p'][0], color='#ff0000')
 diagram.save('reference/_images/logph_diagram_states.svg')
 
-diagram.set_limits(x_min=0, x_max=8000, y_min=-50, y_max=200)
+diagram.set_limits(x_min=2000, x_max=7000, y_min=-50, y_max=225)
 diagram.draw_isolines('Ts')
 
 for key in tespy_results.keys():
@@ -155,6 +159,87 @@ for key in tespy_results.keys():
     diagram.ax.plot(datapoints['s'], datapoints['T'], color='#ff0000')
     diagram.ax.scatter(datapoints['s'][0], datapoints['T'][0], color='#ff0000')
 diagram.save('reference/_images/Ts_diagram_states.svg')
+
+
+data = {
+    'isobaric': {
+        'isoline_property': 'p',
+        'isoline_value': 10,
+        'starting_point_property': 'T',
+        'starting_point_value': -25,
+        'ending_point_property': 'T',
+        'ending_point_value': 150
+    },
+    'isochoric': {
+        'isoline_property': 'v',
+        'isoline_value': 0.035,
+        'starting_point_property': 'h',
+        'starting_point_value': 750,
+        'ending_point_property': 'T',
+        'ending_point_value': 150
+    },
+    'isothermal': {
+        'isoline_property': 'T',
+        'isoline_value': 65,
+        'starting_point_property': 'v',
+        'starting_point_value': 0.01,
+        'ending_point_property': 'v',
+        'ending_point_value': 0.5
+    },
+    'isenthalpic': {
+        'isoline_property': 'h',
+        'isoline_value': 850,
+        'starting_point_property': 'p',
+        'starting_point_value': 200,
+        'ending_point_property': 'v',
+        'ending_point_value': 0.5
+    },
+    'isentropic': {
+        'isoline_property': 's',
+        'isoline_value': 4700,
+        'starting_point_property': 'T',
+        'starting_point_value': -20,
+        'ending_point_property': 'T',
+        'ending_point_value': 150
+    }
+}
+
+for name, specs in data.items():
+    data[name]['datapoints'] = diagram.calc_individual_isoline(**specs)
+
+diagram.set_limits(x_min=0, x_max=2100, y_min=1e-1, y_max=2e2)
+mydata = {
+    'Q': {'values': np.linspace(0, 1, 11)},
+    'T': {'values': np.arange(-50, 201, 25)}}
+diagram.draw_isolines('logph', isoline_data=mydata)
+for key, specs in data.items():
+    datapoints = specs['datapoints']
+    diagram.ax.plot(specs['datapoints']['h'], specs['datapoints']['p'], label=key)
+diagram.ax.legend(loc='lower right')
+diagram.save('reference/_images/logph_NH3_isolines.svg')
+
+diagram.set_limits(x_min=0, x_max=7000, y_min=-50, y_max=201)
+diagram.draw_isolines('Ts')
+for key, specs in data.items():
+    datapoints = specs['datapoints']
+    diagram.ax.plot(specs['datapoints']['s'], specs['datapoints']['T'], label=key)
+diagram.ax.legend(loc='lower right')
+diagram.save('reference/_images/Ts_NH3_isolines.svg')
+
+data = {
+    'isoline_property': 'p',
+    'isoline_value': 10,
+    'isoline_value_end': 9,
+    'starting_point_property': 'h',
+    'starting_point_value': 350,
+    'ending_point_property': 'h',
+    'ending_point_value': 1750
+}
+datapoints = diagram.calc_individual_isoline(**data)
+diagram.draw_isolines('Ts')
+for specs in data.values():
+    diagram.ax.plot(datapoints['s'], datapoints['T'])
+diagram.save('reference/_images/Ts_NH3_pressure_loss.svg')
 
 
 extensions = [

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -250,6 +250,14 @@ diagram's respective unit system.
     for name, specs in data.items():
         data[name]['datapoints'] = diagram.calc_individual_isoline(**specs)
 
+With these data, it is possible to plot to your diagram simply by plotting on
+the :code:`diagram.ax` object, which is a
+:code:`matplotlib.axes._subplots.AxesSubplot` object. Therefore all matplolib
+plotting functionalities are available. Simply pass the data of the x and y
+property of your diagram, e.g. to the :code:`plot()` method.
+
+.. code-block:: python
+
     diagram.set_limits(x_min=0, x_max=2100, y_min=1e-1, y_max=2e2)
     mydata = {
         'Q': {'values': np.linspace(0, 1, 11)},
@@ -272,7 +280,7 @@ diagram's respective unit system.
 .. figure:: reference/_images/logph_NH3_isolines.svg
     :align: center
 
-.. figure:: reference/_images/logph_Ts_isolines.svg
+.. figure:: reference/_images/Ts_NH3_isolines.svg
     :align: center
 
 .. note::
@@ -289,7 +297,10 @@ change in entropy (for isobars and isothermals) or change in pressure (for all
 other lines). This functionality is only supposed to display the change in a
 beautiful way, it does not represent the actual process connecting your
 starting point with your ending point as this would require perfect knowledge
-of the process.
+of the process. In order to generate these data, you need to pass the
+:code:`'isoline_value_end'` keyword to the
+:py:meth:`fluprodia.fluid_property_diagram.FluidPropertyDiagram.calc_individual_isoline`
+method.
 
 .. code-block:: python
 
@@ -311,12 +322,6 @@ of the process.
 .. figure:: reference/_images/Ts_NH3_pressure_loss.svg
     :align: center
 
-With these data, it is possible to plot to your diagram simply by plotting on
-the :code:`diagram.ax` object, which is a
-:code:`matplotlib.axes._subplots.AxesSubplot` object. Therefore all matplolib
-plotting functionalities are available. Simply pass the data of the x and y
-property of your diagrame, e.g. to the :code:`plot()` method.
-
 Plotting States into the Diagram
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -326,7 +331,7 @@ connected states, you will need the :code:`plot()` method. In this example, we
 will plot from a simple heat pump simulation in TESPy [1]_ (for more
 information on TESPy see the
 `online documentation <https://tespy.readthedocs.io/en/master>`_) into a logph
-diagram.
+and a Ts diagram.
 
 .. code-block:: python
 
@@ -360,6 +365,9 @@ diagram.
     diagram.save('Ts_diagram_states.svg')
 
 .. figure:: reference/_images/logph_diagram_states.svg
+    :align: center
+
+.. figure:: reference/_images/Ts_diagram_states.svg
     :align: center
 
 The script to generate the results is the following code snippet. Just add it

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -371,7 +371,9 @@ and a Ts diagram.
     :align: center
 
 The script to generate the results is the following code snippet. Just add it
-into your plotting code and it will create the results shown.
+into your plotting code and it will create the results shown. An interface
+automatically generating a dictionary for every component of the network is
+planned in future versions of TESPy.
 
 .. code-block:: python
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -43,12 +43,12 @@ for their x- and y-axes.
 
 .. code-block:: python
 
-	iso_T = np.arange(-50, 201, 25)
-	diagram.set_isolines(T=iso_T)
-	diagram.calc_isolines()
-	diagram.set_limits(x_min=0, x_max=8000, y_min=-50, y_max=200)
-	diagram.draw_isolines('Ts')
-	diagram.save('Ts_diagram.svg')
+    iso_T = np.arange(-50, 201, 25)
+    diagram.set_isolines(T=iso_T)
+    diagram.calc_isolines()
+    diagram.set_limits(x_min=0, x_max=8000, y_min=-50, y_max=200)
+    diagram.draw_isolines('Ts')
+    diagram.save('Ts_diagram.svg')
 
 .. figure:: reference/_images/Ts_diagram.svg
     :align: center
@@ -61,9 +61,9 @@ call, you need to recalculate the isolines.
 
 .. code-block:: python
 
-	diagram.set_limits(x_min=0, x_max=2100, y_min=1e-1, y_max=2e2)
-	diagram.draw_isolines('logph')
-	diagram.save('logph_diagram.svg')
+    diagram.set_limits(x_min=0, x_max=2100, y_min=1e-1, y_max=2e2)
+    diagram.draw_isolines('logph')
+    diagram.save('logph_diagram.svg')
 
 .. figure:: reference/_images/logph_diagram.svg
     :align: center
@@ -99,10 +99,10 @@ lines of constant temperature every 5 K.
 
 .. code-block:: python
 
-	T = np.arange(-50, 201, 5)
-	Q = np.linspace(0, 1, 41)
-	diagram.set_isolines(T=T, Q=Q)
-	diagram.calc_isolines()
+    T = np.arange(-50, 201, 5)
+    Q = np.linspace(0, 1, 41)
+    diagram.set_isolines(T=T, Q=Q)
+    diagram.calc_isolines()
 
 The following sections shows how to select from all isolines available.
 
@@ -116,12 +116,12 @@ a dictionary holding the required information.
 
 .. code-block:: python
 
-	diagram.set_limits(x_min=0, x_max=2100, y_min=1e-1, y_max=2e2)
-	mydata = {
-	    'Q': {'values': np.linspace(0, 1, 11)},
-	    'T': {'values': np.arange(-50, 201, 25)}}
-	diagram.draw_isolines('logph', isoline_data=mydata)
-	diagram.save('logph_NH3_full.svg')
+    diagram.set_limits(x_min=0, x_max=2100, y_min=1e-1, y_max=2e2)
+    mydata = {
+        'Q': {'values': np.linspace(0, 1, 11)},
+        'T': {'values': np.arange(-50, 201, 25)}}
+    diagram.draw_isolines('logph', isoline_data=mydata)
+    diagram.save('logph_NH3_full.svg')
 
 .. figure:: reference/_images/logph_NH3_full.svg
     :align: center
@@ -135,26 +135,26 @@ numpy array.
 
 .. code-block:: python
 
-	diagram.set_limits(x_min=1000, x_max=1500, y_min=1, y_max=2e2)
-	mydata = {
-	    'T': {
-	        'style': {'color': '#ff0000'},
-	        'values': np.arange(-50, 201, 5)},
-	    'v': {'values': np.array([])}
-	    }
-	diagram.draw_isolines('logph', isoline_data=mydata)
-	diagram.save('logph_NH3_zoomed.svg')
+    diagram.set_limits(x_min=1000, x_max=1500, y_min=1, y_max=2e2)
+    mydata = {
+        'T': {
+            'style': {'color': '#ff0000'},
+            'values': np.arange(-50, 201, 5)},
+        'v': {'values': np.array([])}
+        }
+    diagram.draw_isolines('logph', isoline_data=mydata)
+    diagram.save('logph_NH3_zoomed.svg')
 
 .. figure:: reference/_images/logph_NH3_zoomed.svg
     :align: center
 
 .. note::
 
-	For changing the style of a specific isoline pass the respective keyword
-	and value pairs in a dictionary. The keywords available are the keywords
-	of a :code:`matplotlib.lines.Line2D` object. See
-	https://matplotlib.org/api/_as_gen/matplotlib.lines.Line2D.html#matplotlib.lines.Line2D
-	for more information.
+    For changing the style of a specific isoline pass the respective keyword
+    and value pairs in a dictionary. The keywords available are the keywords
+    of a :code:`matplotlib.lines.Line2D` object. See
+    https://matplotlib.org/api/_as_gen/matplotlib.lines.Line2D.html#matplotlib.lines.Line2D
+    for more information.
 
 Positioning of the isoline lables
 *********************************
@@ -169,33 +169,156 @@ of each isoline within the limits of the view.
 
 .. code-block:: python
 
-	diagram.set_limits(x_min=1000, x_max=1500, y_min=1, y_max=2e2)
-	mydata = {
-	    'T': {
-	        'style': {'color': '#ff0000'},
-	        'values': np.arange(-50, 201, 5),
-	        'label_position': 0.8},
-	    'v': {'values': np.array([])}
-	    }
-	diagram.draw_isolines('logph', isoline_data=mydata)
-	diagram.save('logph_NH3_zoomed_temperature_labels.svg')
+    diagram.set_limits(x_min=1000, x_max=1500, y_min=1, y_max=2e2)
+    mydata = {
+        'T': {
+            'style': {'color': '#ff0000'},
+            'values': np.arange(-50, 201, 5),
+            'label_position': 0.8},
+        'v': {'values': np.array([])}
+        }
+    diagram.draw_isolines('logph', isoline_data=mydata)
+    diagram.save('logph_NH3_zoomed_temperature_labels.svg')
 
 .. figure:: reference/_images/logph_NH3_zoomed_temperature_labels.svg
     :align: center
 
 .. note::
 
-	The placing method of the labels is not fully satisfactory at the moment.
-	If you have ideas, how to place the labels in an improved way, we are
-	looking forward for you suggestions.
+    The placing method of the labels is not fully satisfactory at the moment.
+    If you have ideas, how to place the labels in an improved way, we are
+    looking forward for you suggestions.
+
+Plotting individual isolines (and isolike lines)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+FluProDia offers a method to generate data for individual isolines with a
+specified starting and a specified ending point. Use the method
+:py:meth:`fluprodia.fluid_property_diagram.FluidPropertyDiagram.calc_individual_isoline`
+to create datapoints for the isoline. The method returns a dictionary
+containing the datapoints in numpy arrays using the property name as
+respective key. Therefore, independent of the diagram you want to draw, you
+will have all data available. Following, we will draw all available isolines
+into a Ts and a logph diagram. Each property value must be passed in the
+diagram's respective unit system.
+
+.. code-block:: python
+
+    data = {
+        'isobaric': {
+            'isoline_property': 'p',
+            'isoline_value': 10,
+            'starting_point_property': 'T',
+            'starting_point_value': -25,
+            'ending_point_property': 'T',
+            'ending_point_value': 150
+        },
+        'isochoric': {
+            'isoline_property': 'v',
+            'isoline_value': 0.035,
+            'starting_point_property': 'h',
+            'starting_point_value': 750,
+            'ending_point_property': 'T',
+            'ending_point_value': 150
+        },
+        'isothermal': {
+            'isoline_property': 'T',
+            'isoline_value': 65,
+            'starting_point_property': 'v',
+            'starting_point_value': 0.01,
+            'ending_point_property': 'v',
+            'ending_point_value': 0.5
+        },
+        'isenthalpic': {
+            'isoline_property': 'h',
+            'isoline_value': 850,
+            'starting_point_property': 'p',
+            'starting_point_value': 200,
+            'ending_point_property': 'v',
+            'ending_point_value': 0.5
+        },
+        'isentropic': {
+            'isoline_property': 's',
+            'isoline_value': 4700,
+            'starting_point_property': 'T',
+            'starting_point_value': -20,
+            'ending_point_property': 'T',
+            'ending_point_value': 150
+        }
+    }
+
+    for name, specs in data.items():
+        data[name]['datapoints'] = diagram.calc_individual_isoline(**specs)
+
+    diagram.set_limits(x_min=0, x_max=2100, y_min=1e-1, y_max=2e2)
+    mydata = {
+        'Q': {'values': np.linspace(0, 1, 11)},
+        'T': {'values': np.arange(-50, 201, 25)}}
+    diagram.draw_isolines('logph', isoline_data=mydata)
+    for key, specs in data.items():
+        datapoints = specs['datapoints']
+        diagram.ax.plot(specs['datapoints']['h'], specs['datapoints']['p'], label=key)
+    diagram.ax.legend(loc='lower right')
+    diagram.save('logph_NH3_isolines.svg')
+
+    diagram.set_limits(x_min=0, x_max=7000, y_min=-50, y_max=201)
+    diagram.draw_isolines('Ts')
+    for key, specs in data.items():
+        datapoints = specs['datapoints']
+        diagram.ax.plot(specs['datapoints']['s'], specs['datapoints']['T'], label=key)
+    diagram.ax.legend(loc='lower right')
+    diagram.save('Ts_NH3_isolines.svg')
+
+.. figure:: reference/_images/logph_NH3_isolines.svg
+    :align: center
+
+.. figure:: reference/_images/logph_Ts_isolines.svg
+    :align: center
+
+.. note::
+
+    Note that the :code:`starting_point_property` and the
+    :code:`ending_point_property` do not need to be identical! E.g., you can
+    draw an isobaric line starting at a specific entropy and ending at a
+    specific temperature.
+
+On top of that, e.g. in order to display a pressure loss in a heat exchanger,
+you can have different values for the (iso)line at the starting and the ending
+points. The (then former) isoline property will be changed linearly to either
+change in entropy (for isobars and isothermals) or change in pressure (for all
+other lines). This functionality is only supposed to display the change in a
+beautiful way, it does not represent the actual process connecting your
+starting point with your ending point as this would require perfect knowledge
+of the process.
+
+.. code-block:: python
+
+    data = {
+        'isoline_property': 'p',
+        'isoline_value': 10,
+        'isoline_value_end': 9,
+        'starting_point_property': 'h',
+        'starting_point_value': 350,
+        'ending_point_property': 'h',
+        'ending_point_value': 1750
+    }
+    datapoints = diagram.calc_individual_isoline(**data)
+    diagram.draw_isolines('Ts')
+    for specs in data.values():
+        diagram.ax.plot(datapoints['s'], datapoints['T'])
+    diagram.save('Ts_NH3_pressure_loss.svg')
+
+.. figure:: reference/_images/Ts_NH3_pressure_loss.svg
+    :align: center
+
+With these data, it is possible to plot to your diagram simply by plotting on
+the :code:`diagram.ax` object, which is a
+:code:`matplotlib.axes._subplots.AxesSubplot` object. Therefore all matplolib
+plotting functionalities are available. Simply pass the data of the x and y
+property of your diagrame, e.g. to the :code:`plot()` method.
 
 Plotting States into the Diagram
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-It is possible to plot to your diagram simply by plotting on the
-:code:`diagram.ax` object, which is a
-:code:`matplotlib.axes._subplots.AxesSubplot` object. Therefore all matplolib
-plotting functionalities are available.
 
 For instance, if you want to plot two different states of :code:`NH3` into your
 diagram, you could use the :code:`scatter()` method. If you want to have
@@ -207,71 +330,122 @@ diagram.
 
 .. code-block:: python
 
-	diagram.set_limits(x_min=0, x_max=2100, y_min=1e-1, y_max=2e2)
-	mydata = {
-		'Q': {'values': np.linspace(0, 1, 11)},
-		'T': {'values': np.arange(-50, 201, 25)}}
-	diagram.draw_isolines('logph', isoline_data=mydata)
+    tespy_results = run_simple_heat_pump_model()
+    for key, data in tespy_results.items():
+        tespy_results[key]['datapoints'] = diagram.calc_individual_isoline(**data)
 
-	tespy_results = run_simple_heat_pump_model()
+    diagram.set_limits(x_min=0, x_max=2100, y_min=1e0, y_max=2e2)
+    mydata = {
+        'Q': {'values': np.linspace(0, 1, 11)},
+        'T': {
+            'values': np.arange(-25, 226, 25),
+            'style': {'color': '#000000'}
+        }
+    }
+    diagram.draw_isolines('logph', isoline_data=mydata)
 
-	diagram.ax.scatter(tespy_results['h'], tespy_results['p'])
-	diagram.ax.plot(tespy_results['h'], tespy_results['p'])
-	diagram.save('logph_diagram_states.svg')
+    for key in tespy_results.keys():
+        datapoints = tespy_results[key]['datapoints']
+        diagram.ax.plot(datapoints['h'], datapoints['p'], color='#ff0000')
+        diagram.ax.scatter(datapoints['h'][0], datapoints['p'][0], color='#ff0000')
+    diagram.save('logph_diagram_states.svg')
+
+    diagram.set_limits(x_min=2000, x_max=7000, y_min=-50, y_max=225)
+    diagram.draw_isolines('Ts')
+
+    for key in tespy_results.keys():
+        datapoints = tespy_results[key]['datapoints']
+        diagram.ax.plot(datapoints['s'], datapoints['T'], color='#ff0000')
+        diagram.ax.scatter(datapoints['s'][0], datapoints['T'][0], color='#ff0000')
+    diagram.save('Ts_diagram_states.svg')
 
 .. figure:: reference/_images/logph_diagram_states.svg
-	:align: center
+    :align: center
 
 The script to generate the results is the following code snippet. Just add it
 into your plotting code and it will create the results shown.
 
 .. code-block:: python
 
-	from tespy.components import (
-	compressor, cycle_closer, heat_exchanger_simple, valve)
-	from tespy.connections import connection
-	from tespy.networks import network
+    from tespy.components import (
+    compressor, cycle_closer, heat_exchanger_simple, valve)
+    from tespy.connections import connection
+    from tespy.networks import network
 
 
-	def run_simple_heat_pump_model():
-		nw = network(['NH3'], T_unit='C', p_unit='bar', h_unit='kJ / kg')
-		nw.set_attr(iterinfo=False)
-		cp = compressor('compressor')
-		cc = cycle_closer('cycle_closer')
-		cd = heat_exchanger_simple('condenser')
-		va = valve('expansion valve')
-		ev = heat_exchanger_simple('evaporator')
+    def run_simple_heat_pump_model():
+        nw = network(['NH3'], T_unit='C', p_unit='bar', h_unit='kJ / kg')
+        nw.set_attr(iterinfo=False)
+        cp = compressor('compressor')
+        cc = cycle_closer('cycle_closer')
+        cd = heat_exchanger_simple('condenser')
+        va = valve('expansion valve')
+        ev = heat_exchanger_simple('evaporator')
 
-		cp.char_warnings = False
-		cd.char_warnings = False
-		va.char_warnings = False
-		ev.char_warnings = False
+        cp.char_warnings = False
+        cd.char_warnings = False
+        va.char_warnings = False
+        ev.char_warnings = False
 
-		cc_cd = connection(cc, 'out1', cd, 'in1')
-		cd_va = connection(cd, 'out1', va, 'in1')
-		va_ev = connection(va, 'out1', ev, 'in1')
-		ev_cp = connection(ev, 'out1', cp, 'in1')
-		cp_cc = connection(cp, 'out1', cc, 'in1')
+        cc_cd = connection(cc, 'out1', cd, 'in1')
+        cd_va = connection(cd, 'out1', va, 'in1')
+        va_ev = connection(va, 'out1', ev, 'in1')
+        ev_cp = connection(ev, 'out1', cp, 'in1')
+        cp_cc = connection(cp, 'out1', cc, 'in1')
 
-		nw.add_conns(cc_cd, cd_va, va_ev, ev_cp, cp_cc)
+        nw.add_conns(cc_cd, cd_va, va_ev, ev_cp, cp_cc)
 
-		cd.set_attr(pr=1, Q=-1e6)
-		ev.set_attr(pr=1)
-		cp.set_attr(eta_s=0.9)
+        cd.set_attr(pr=0.95, Q=-1e6)
+        ev.set_attr(pr=0.9)
+        cp.set_attr(eta_s=0.9)
 
-		cc_cd.set_attr(fluid={'NH3': 1})
-		cd_va.set_attr(Td_bp=-5, T=85)
-		ev_cp.set_attr(Td_bp=5, T=15)
-		nw.solve('design')
+        cc_cd.set_attr(fluid={'NH3': 1})
+        cd_va.set_attr(Td_bp=-5, T=85)
+        ev_cp.set_attr(Td_bp=5, T=15)
+        nw.solve('design')
 
-		result_dict = {
-			prop: [conn.get_attr(prop).val for conn in nw.conns.index]
-			for prop in ['p', 'h']
-		}
-		return result_dict
+        result_dict = {
+            'compressor': {
+                'isoline_property': 's',
+                'isoline_value': ev_cp.s.val,
+                'isoline_value_end': cp_cc.s.val,
+                'starting_point_property': 'p',
+                'starting_point_value': ev_cp.p.val,
+                'ending_point_property': 'p',
+                'ending_point_value': cp_cc.p.val
+            },
+            'condenser': {
+                'isoline_property': 'p',
+                'isoline_value': cc_cd.p.val,
+                'isoline_value_end': cd_va.p.val,
+                'starting_point_property': 's',
+                'starting_point_value': cc_cd.s.val,
+                'ending_point_property': 's',
+                'ending_point_value': cd_va.s.val
+            },
+            'valve': {
+                'isoline_property': 'h',
+                'isoline_value': cd_va.h.val,
+                'isoline_value_end': va_ev.h.val,
+                'starting_point_property': 'p',
+                'starting_point_value': cd_va.p.val,
+                'ending_point_property': 'p',
+                'ending_point_value': va_ev.p.val
+            },
+            'evaporator': {
+                'isoline_property': 'p',
+                'isoline_value': va_ev.p.val,
+                'isoline_value_end': ev_cp.p.val,
+                'starting_point_property': 's',
+                'starting_point_value': va_ev.s.val,
+                'ending_point_property': 's',
+                'ending_point_value': ev_cp.s.val
+            }
+        }
+        return result_dict
 
 .. note::
 
     The values for plotting must be passed in the diagrams unit system.
 
-.. [1] Witte, F., 2020. Thermal Engineering Systems in Python (Version v0.2.2). Zenodo. http://doi.org/10.5281/zenodo.3699275
+.. [1] Witte, F., 2020. Thermal Engineering Systems in Python (Version v0.3.4). Zenodo. http://doi.org/10.5281/zenodo.3699275

--- a/src/fluprodia/fluid_property_diagram.py
+++ b/src/fluprodia/fluid_property_diagram.py
@@ -15,84 +15,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-def newton(func, deriv, params, y, **kwargs):
-    r"""
-    Find zero crossings with 1-D newton algorithm.
-
-    Parameters
-    ----------
-    func : function
-        Function to find zero crossing in,
-        :math:`0=y-func\left(x,\text{params}\right)`.
-
-    deriv : function
-        First derivative of the function.
-
-    params : list
-        Additional parameters for function, optional.
-
-    y : float
-        Target function value.
-
-    val0 : float
-        Starting value, default: val0=300.
-
-    valmin : float
-        Lower value boundary, default: valmin=70.
-
-    valmax : float
-        Upper value boundary, default: valmax=3000.
-
-    max_iter : int
-        Maximum number of iterations, default: max_iter=10.
-
-    Returns
-    -------
-    val : float
-        x-value of zero crossing.
-
-    Note
-    ----
-    Algorithm
-
-    .. math::
-
-        x_{i+1} = x_{i} - \frac{f(x_{i})}{\frac{df}{dx}(x_{i})}\\
-        f(x_{i}) \leq \epsilon
-    """
-    # default valaues
-    x = kwargs.get('val0', 300)
-    valmin = kwargs.get('valmin', 70)
-    valmax = kwargs.get('valmax', 3000)
-    max_iter = kwargs.get('max_iter', 10)
-
-    # start newton loop
-    res = 1
-    i = 0
-    while abs(res) >= 1e-6:
-        # calculate function residual and new value
-        res = y - func(params, x)
-        x += res / deriv(params, x)
-
-        # check for value ranges
-        if x < valmin:
-            x = valmin
-        if x > valmax:
-            x = valmax
-        i += 1
-
-        if i > max_iter:
-            msg = ('Newton algorithm was not able to find a feasible value '
-                   'for function ' + str(func) + '. Current value with x=' +
-                   str(x) + ' is ' + str(func(params, x)) +
-                   ', target value is ' + str(y) + '.')
-            logging.debug(msg)
-
-            break
-
-    return x
-
-
 def beautiful_unit_string(unit):
     r"""Convert unit fractions to latex.
 
@@ -1210,15 +1132,3 @@ class FluidPropertyDiagram:
                 self.converters[property][self.units[property]][0])
         else:
             return value / self.converters[property][self.units[property]]
-
-    def find_Q_crossing(self, *args, p):
-        p1, p2, s1, s2, Q = args
-        self.state.update(CP.PQ_INPUTS, p, Q)
-        s = self.state.smass()
-        return (s - s1) / (s2 - s1) - ( - p1) / (p2 - p1)
-
-    def find_Q_crossing_deriv(self, *args, p):
-        d = 1
-        return (
-            self.find_Q_crossing(*args, p + d) -
-            self.find_Q_crossing(*args, p - d)) / (2 * d)

--- a/src/fluprodia/fluid_property_diagram.py
+++ b/src/fluprodia/fluid_property_diagram.py
@@ -765,6 +765,54 @@ class FluidPropertyDiagram:
             self.entropy[s]['s'] = np.asarray(self.entropy[s]['s'])
             self.entropy[s]['h'] = np.asarray(self.entropy[s]['h'])
 
+    def draw_individual_isoline(
+            self, diagram_type=None, line_type=None, line_value=None,
+            line_styling={}, starting_property={}, ending_property={}):
+        """Draw an individual isoline within a specific diagram type.
+
+        Pass the isoline type, its value in the diagrams unit system, as well
+        as the start and the endpoint of the line. Styling can be changed
+        using the line_style property.
+
+        Parameters
+        ----------
+        diagram_type : str
+            Which type of diagram are the lines drawn into.
+
+        line_type : str
+            Type of the isoline. Choose from :code:`line_type='...'`:
+
+            - :code:`'isobar'` or :code:`'p'`
+            - :code:`'isochor'` or :code:`'v'`
+            - :code:`'isotherm'` or :code:`'T'`
+            - :code:`'isenthalp'` or :code:`'h'`
+            - :code:`'isentropic'` or :code:`'s'`
+
+        line_value : float
+            Value of the isoline specified in the respective unit.
+
+        isoline_style : dict
+            Dictionary holding the styling information of isoline to
+            be drawn. The dictionary holds keyword arguments of a
+            :code:`matplotlib.lines.Line2D` object. See
+            https://matplotlib.org/api/_as_gen/matplotlib.lines.Line2D.html#matplotlib.lines.Line2D
+            for more information. This parameter is optional.
+
+        starting_property : dict
+            Dictionary holding the starting property and its value in the
+            unit used for plotting the diagram, e.g.
+            :code:`starting_property{'p': 1e5}`
+
+        ending_property : dict
+            Dictionary holding the ending property and its value in the
+            unit used for plotting the diagram, e.g.
+            :code:`ending_property{'p': 1e4}`
+
+        Example
+        -------
+        A full example can be found in the class documentation.
+        """
+
     def draw_isolines(self, diagram_type, isoline_data={}):
         """Draw the isolines of a specific diagram type.
 


### PR DESCRIPTION
There is an option to change the value of the then no more isoline, e.g. in order to plot a heat transfer with pressure losses. The change of the "isoline" value and therefore its course in the diagram cannot represent the actual process happening, as there are no information on the actual process. If you had all fluid property information along the line, you could plot it anyway.

Resolve #3 