### PR TITLE
Improve writing JSON file method.

### DIFF
--- a/src/fluprodia/fluid_property_diagram.py
+++ b/src/fluprodia/fluid_property_diagram.py
@@ -626,7 +626,7 @@ class FluidPropertyDiagram:
             os.makedirs(directory)
 
         with open(path, "w", encoding="utf-8") as f:
-            f.write(json.dumps(data, indent=2))
+            json.dump(data, f, indent=2)
 
     def calc_individual_isoline(
             self, isoline_property=None,


### PR DESCRIPTION
When writing JSON data to a file, the `json.dumps` method is used to create a string in JSON format, which is then written to disk with the `write` method of the `file` object. The extra conversion is not necessary, since the `json.dump` method directly writes the data to the file, without the extra step of converting the data to a string. See for example [this comparison on StackOverflow](https://stackoverflow.com/questions/36059194/what-is-the-difference-between-json-dump-and-json-dumps-in-python) or the [json module documentation](https://docs.python.org/3/library/json.html).