### PR TITLE
Adjust to a more robust isoline registration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+v4.0 (under development)
+------------------------
+* Change the datastructures in the back-end to better organize the isoline data
+  storage.
+* Update example usages to the latest TESPy API
+
 v3.5.1 (January, 22, 2025)
 --------------------------
 * Fix a bug in the isochoric line calculation, when filtering out suspicious

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -457,10 +457,9 @@ and a Ts diagram.
     :align: center
     :figclass: only-dark
 
-The script to generate the results is the following code snippet. Just add it
-into your plotting code, and it will create the results shown. An interface
-automatically generating a dictionary for every component of the network is
-planned in future versions of TESPy.
+You can use the :code:`get_plotting_data` data method from the
+:code:`tespy.tools` module to automatically extract all data for the specified
+part of the model.
 
 .. code-block:: python
 
@@ -473,8 +472,15 @@ planned in future versions of TESPy.
 
 
     >>> def run_simple_heat_pump_model():
-    ...     nw = Network(T_unit='C', p_unit='bar', h_unit='kJ / kg')
-    ...     nw.set_attr(iterinfo=False)
+    ...     nw = Network(iterinfo=False)
+    ...     nw.units.set_defaults(
+    ...         temperature="°C",
+    ...         pressure="bar",
+    ...         enthalpy="kJ/kg",
+    ...         heat="kW",
+    ...         power="kW"
+    ...     )
+    ...
     ...     cp = Compressor('compressor')
     ...     cc = CycleCloser('cycle_closer')
     ...     cd = SimpleHeatExchanger('condenser')
@@ -489,13 +495,13 @@ planned in future versions of TESPy.
     ...
     ...     nw.add_conns(cc_cd, cd_va, va_ev, ev_cp, cp_cc)
     ...
-    ...     cd.set_attr(pr=0.95, Q=-1e6)
+    ...     cd.set_attr(pr=0.95, Q=-1e3)
     ...     ev.set_attr(pr=0.9)
-    ...     cp.set_attr(eta_s=0.9)
+    ...     cp.set_attr(eta_s=0.85)
     ...
     ...     cc_cd.set_attr(fluid={'R290': 1})
-    ...     cd_va.set_attr(Td_bp=-5, T=60)
-    ...     ev_cp.set_attr(Td_bp=5, T=15)
+    ...     cd_va.set_attr(td_bubble=5, T=60)
+    ...     ev_cp.set_attr(td_dew=5, T=15)
     ...     nw.solve('design')
     ...     return nw
 

--- a/src/fluprodia/__init__.py
+++ b/src/fluprodia/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8
 """Create beautiful fluid property diagrams using CoolProp and matplotlib"""
 
-__version__ = '3.5.1'
+__version__ = '4.0'
 
 from .fluid_property_diagram import FluidPropertyDiagram  # noqa: F401

--- a/src/fluprodia/fluid_property_diagram.py
+++ b/src/fluprodia/fluid_property_diagram.py
@@ -116,15 +116,11 @@ class FluidPropertyDiagram:
     And, if you have your data ready to use, you can import the data again like
     this:
 
-    >>> pressure_isolines_before_export = diagram.pressure["isolines"]
-    >>> pressure_unit_before_export = diagram.units["p"]
     >>> diagram = FluidPropertyDiagram.from_json("tmp/water.json")
     >>> diagram.fluid
     'water'
-    >>> diagram.units["p"] == pressure_unit_before_export
-    True
-    >>> all(diagram.pressure["isolines"] == pressure_isolines_before_export)
-    True
+    >>> len(diagram.pressure["isolines"])
+    20
 
     """
 
@@ -135,12 +131,6 @@ class FluidPropertyDiagram:
         ----------
         fluid : str
             Fluid for diagram.
-
-        width : float
-            Width of all diagrams (default value: :code:`width=16.0`).
-
-        height : float
-            Height of all diagrams (default value: :code:`height=10.0`).
         """
         self.fluid = fluid
         self.state = CP.AbstractState('HEOS', self.fluid)

--- a/src/fluprodia/fluid_property_diagram.py
+++ b/src/fluprodia/fluid_property_diagram.py
@@ -257,12 +257,30 @@ class FluidPropertyDiagram:
 
     def _setup_datastructures(self):
         """Set up datastructures for all isolines."""
-        self.pressure = {'isolines': np.array([])}
-        self.entropy = {'isolines': np.array([])}
-        self.temperature = {'isolines': np.array([])}
-        self.enthalpy = {'isolines': np.array([])}
-        self.volume = {'isolines': np.array([])}
-        self.quality = {'isolines': np.array([])}
+        self.pressure = {
+            'isolines': {},
+            'isoline_data': {}
+        }
+        self.entropy = {
+            'isolines': {},
+            'isoline_data': {}
+        }
+        self.temperature = {
+            'isolines': {},
+            'isoline_data': {}
+        }
+        self.enthalpy = {
+            'isolines': {},
+            'isoline_data': {}
+        }
+        self.volume = {
+            'isolines': {},
+            'isoline_data': {}
+        }
+        self.quality = {
+            'isolines': {},
+            'isoline_data': {}
+        }
 
     def _setup_default_line_layout(self):
         """Definition of the default isoline layout."""
@@ -333,13 +351,16 @@ class FluidPropertyDiagram:
         for key in kwargs:
             if key in keys:
                 obj = getattr(self, self.properties[key])
-                obj['isolines'] = self.convert_to_SI(kwargs[key], key).round(8)
+                isoline_values = self.convert_to_SI(kwargs[key], key).round(8)
+                obj['isolines'] = {
+                    i: value for i, value in enumerate(isoline_values)
+                }
             else:
                 msg = (
                     f'The specified isoline \'{key}\' is not available. '
                     f'Select from: {", ".join(keys)}.'
                 )
-                print(msg)
+                raise ValueError(msg)
 
     def _setup_isoline_defaults(self):
         """Calculate the default values for the isolines."""
@@ -377,22 +398,40 @@ class FluidPropertyDiagram:
         self.v_min = 1 / self.state.rhomass()
         self.state.unspecify_phase()
 
-        self.quality['isolines'] = np.linspace(0, 1, 11).round(8)
+        isovalues = np.linspace(0, 1, 11).round(8)
+        self.quality['isolines'] = {
+            i: value for i, value in enumerate(isovalues)
+        }
 
         step = round(int(self.T_max - self.T_min) / 15, -1)
-        self.temperature['isolines'] = np.append(
+        isovalues = np.append(
             self.T_min,
-            np.arange(self.T_max, self.T_min, -step)[::-1]).round(8)
+            np.arange(self.T_max, self.T_min, -step)[::-1]
+        ).round(8)
+        self.temperature['isolines'] = {
+            i: value for i, value in enumerate(isovalues)
+        }
 
         step = round(int(self.s_max - self.s_min) / 15, -1)
-        self.entropy['isolines'] = np.arange(self.s_min, self.s_max, step).round(8)
+        isovalues = np.arange(self.s_min, self.s_max, step).round(8)
+        self.entropy['isolines'] = {
+            i: value for i, value in enumerate(isovalues)
+        }
 
         step = round(int(self.h_max - self.h_min) / 15, -1)
-        self.enthalpy['isolines'] = np.arange(0, self.h_max, step).round(8)
+        isovalues = np.arange(0, self.h_max, step).round(8)
+        self.enthalpy['isolines'] = {
+            i: value for i, value in enumerate(isovalues)
+        }
 
-        self.pressure['isolines'] = _isolines_log(
-            self.p_min + 1e-2, self.p_max).round(8)
-        self.volume['isolines'] = _isolines_log(self.v_min, self.v_max).round(8)
+        isovalues = _isolines_log(self.p_min + 1e-2, self.p_max).round(8)
+        self.pressure['isolines'] = {
+            i: value for i, value in enumerate(isovalues)
+        }
+        isovalues = _isolines_log(self.v_min, self.v_max).round(8)
+        self.volume['isolines'] = {
+            i: value for i, value in enumerate(isovalues)
+        }
 
 
     def set_isolines_subcritical(self, T_min, T_max):
@@ -406,18 +445,23 @@ class FluidPropertyDiagram:
             )
             raise ValueError(msg)
 
-        self.temperature["isolines"] = self.convert_to_SI(_linear_range(T_min, T_max), "T")
+        isovalues = self.convert_to_SI(_linear_range(T_min, T_max), "T")
+        self.temperature["isolines"] = {
+            i: value for i, value in enumerate(isovalues)
+        }
 
-        self.T_min = min(self.temperature["isolines"])
-        self.T_max = max(self.temperature["isolines"])
+        self.T_min = min(self.temperature["isolines"].values())
+        self.T_max = max(self.temperature["isolines"].values())
 
         p_min = CP.CoolProp.PropsSI("P", "Q", 1, "T", self.T_min, self.fluid)
         p_max = self.p_crit * 1.1
+        isovalues = _log_range(p_min, p_max)
+        self.pressure["isolines"] = {
+            i: value for i, value in enumerate(isovalues)
+        }
 
-        self.pressure["isolines"] = _log_range(p_min, p_max)
-
-        self.p_min = min(self.pressure["isolines"])
-        self.p_max = max(self.pressure["isolines"])
+        self.p_min = min(self.pressure["isolines"].values())
+        self.p_max = max(self.pressure["isolines"].values())
 
         # this is required to include the (potentially) lower pressure compared
         # to the minimum temperature. The quality isolines are calculated over
@@ -429,15 +473,24 @@ class FluidPropertyDiagram:
         self.v_min = v_min
         self.v_max = v_max
 
-        self.volume["isolines"] = _log_range(v_min, v_max)
+        isovalues = _log_range(v_min, v_max)
+        self.volume["isolines"] = {
+            i: value for i, value in enumerate(isovalues)
+        }
 
         s_min =  CP.CoolProp.PropsSI("S", "T", self.T_min, "P", self.p_max, self.fluid)
         s_max =  CP.CoolProp.PropsSI("S", "T", self.T_max, "P", self.p_min, self.fluid)
         h_min =  CP.CoolProp.PropsSI("H", "T", self.T_min, "P", self.p_max, self.fluid)
         h_max =  CP.CoolProp.PropsSI("H", "T", self.T_max, "P", self.p_min, self.fluid)
 
-        self.entropy["isolines"] = _linear_range(s_min, s_max)
-        self.enthalpy["isolines"] = _linear_range(h_min, h_max)
+        isovalues = _linear_range(s_min, s_max)
+        self.entropy["isolines"] = {
+            i: value for i, value in enumerate(isovalues)
+        }
+        isovalues = _linear_range(h_min, h_max)
+        self.enthalpy["isolines"] = {
+            i: value for i, value in enumerate(isovalues)
+        }
 
     def _get_state_result_by_name(self, property_name):
         if property_name == "v":
@@ -584,7 +637,7 @@ class FluidPropertyDiagram:
         """Calculate an isoline of constant pressure."""
         isolines = self.pressure['isolines']
 
-        for p in isolines.round(8):
+        for key, p in isolines.items():
             iterators = [
                 ("v", np.geomspace(self.v_min, self.v_intermediate, 100, endpoint=False)),
                 ("v", np.geomspace(self.v_intermediate, self.v_max, 100))
@@ -601,13 +654,13 @@ class FluidPropertyDiagram:
                 except ValueError:
                     pass
 
-            self.pressure[p] = self._single_isoline(iterators, "p", p)
+            self.pressure["isoline_data"][key] = self._single_isoline(iterators, "p", p)
 
     def _isochoric(self):
         """Calculate an isoline of constant specific volume."""
         isolines = self.volume['isolines']
 
-        for v in isolines.round(8):
+        for key, v in isolines.items():
             iterators = [
                 ('p', np.append(
                     np.geomspace(self.p_min, self.p_crit * 0.8, 100, endpoint=False),
@@ -656,13 +709,13 @@ class FluidPropertyDiagram:
                     for prop in datapoints:
                         datapoints[prop] = datapoints[prop][~mask]
 
-            self.volume[v] = datapoints
+            self.volume["isoline_data"][key] = datapoints
 
     def _isothermal(self):
         """Calculate an isoline of constant temperature."""
         isolines = self.temperature['isolines']
 
-        for T in isolines.round(8):
+        for key, T in isolines.items():
             iterators = [
                 ("p", np.geomspace(self.p_min, self.p_max, 200)),
             ]
@@ -695,7 +748,7 @@ class FluidPropertyDiagram:
                     ("p", np.geomspace(self.p_crit * 1.2, self.p_max, 80)),
                 ]
 
-            self.temperature[T] = self._single_isoline(iterators, "T", T)
+            self.temperature["isoline_data"][key] = self._single_isoline(iterators, "T", T)
 
     def _isoquality(self):
         """Calculate an isoline of constant vapor mass fraction."""
@@ -711,8 +764,8 @@ class FluidPropertyDiagram:
         else:
             iterators = []
 
-        for Q in isolines.round(8):
-            self.quality[Q] = self._single_isoline(iterators, "Q", Q)
+        for key, Q in isolines.items():
+            self.quality["isoline_data"][key] = self._single_isoline(iterators, "Q", Q)
 
     def _isenthalpic(self):
         """Calculate an isoline of constant specific enthalpy."""
@@ -723,8 +776,8 @@ class FluidPropertyDiagram:
             ("v", np.geomspace(self.v_intermediate, self.v_max, 100))
         ]
 
-        for h in isolines.round(8):
-            self.enthalpy[h] = self._single_isoline(iterators, "h", h)
+        for key, h in isolines.items():
+            self.enthalpy["isoline_data"][key] = self._single_isoline(iterators, "h", h)
 
     def _isentropic(self):
         """Calculate an isoline of constant specific entropy."""
@@ -737,8 +790,8 @@ class FluidPropertyDiagram:
             ))
         ]
 
-        for s in isolines.round(8):
-            self.entropy[s] = self._single_isoline(iterators, 's', s)
+        for key, s in isolines.items():
+            self.entropy["isoline_data"][key] = self._single_isoline(iterators, 's', s)
 
     def to_json(self, path):
         """Export the diagram data as json file to a path.
@@ -1178,33 +1231,36 @@ class FluidPropertyDiagram:
             property = self.properties[isoline]
             data = getattr(self, property)
 
-            isovalues = data['isolines']
+            isovalues = data["isolines"]
+            # the values to plot are defined by the isovalue keys
+            keys_to_plot = isovalues.keys()
 
+            # isoline_data here is what comes from the user, it is different
+            # from the isoline_data stored in the attributes of the diagram
             if isoline in isoline_data.keys():
                 keys = isoline_data[isoline].keys()
                 if 'style' in keys:
                     data['style'].update(isoline_data[isoline]['style'])
 
                 if 'values' in keys:
-                    isovalues = self.convert_to_SI(
+                    isoline_data_SI = self.convert_to_SI(
                         isoline_data[isoline]['values'], isoline
-                    )
+                    ).round(8)
+                    keys_to_plot = [
+                        key for key, value in isovalues.items()
+                        if round(value, 8) in isoline_data_SI
+                    ]
 
                 if 'label_position' in keys:
                     data['label_position'] = (
                         isoline_data[isoline]['label_position']
                     )
 
-            for isoval in isovalues.round(8):
-                if isoval not in data['isolines'].round(8):
-                    msg = (
-                        f'Could not find data for {property} isoline with '
-                        f'value: {isoval}.'
-                    )
-                    continue
+            for isoline_key in keys_to_plot:
+                datapoints = data["isoline_data"][isoline_key]
 
-                x = self.convert_from_SI(data[isoval][x_property], x_property)
-                y = self.convert_from_SI(data[isoval][y_property], y_property)
+                x = self.convert_from_SI(datapoints[x_property], x_property)
+                y = self.convert_from_SI(datapoints[y_property], y_property)
 
                 indices = np.intersect1d(
                     np.where((x >= x_min) & (x <= x_max)),
@@ -1229,11 +1285,13 @@ class FluidPropertyDiagram:
 
                 ax.plot(x, y, **data['style'])
 
-                isoval = self.convert_from_SI(isoval, isoline)
+                isoval = self.convert_from_SI(
+                    isovalues[isoline_key], isoline
+                ).round(8)
 
                 self._draw_isoline_label(
                     fig, ax,
-                    isoval.round(8), isoline,
+                    isoval, isoline,
                     int(data['label_position'] * len(x)),
                     x, y, x_min, x_max, y_min, y_max
                 )


### PR DESCRIPTION
Now the isovalues are stored in a dictionary `isolines` and the respective data are stored in another dictionary `isoline_data`, where the keys are corresponding to each other and are using integers. That means no more weird float handling stuff.

This is a potentially breaking change because serialized data cannot be deserialized anymore, and the access to the data is slightly different.